### PR TITLE
Fix internalMomentValue being modified by canNext() and canBack()

### DIFF
--- a/src/components/VueMonthlyPicker.vue
+++ b/src/components/VueMonthlyPicker.vue
@@ -121,16 +121,16 @@ export default {
     },
     canBack () {
       if (!this.min) return true
-      const currentVal = this.internalMomentValue.startOf('year')
+      const currentVal = this.internalMomentValue.clone().startOf('year')
       return this.min.isBefore(currentVal)
     },
     canNext () {
       if (!this.max) return true
-      const currentVal = this.internalMomentValue.endOf('year')
+      const currentVal = this.internalMomentValue.clone().endOf('year')
       return currentVal.isBefore(this.max)
     },
     internalMomentValue () {
-      const yrMonth = this.year + '/' + (this.month.length < 2 ? '0' + this.month : this.month)
+      const yrMonth = this.year + '/' + this.month
       return moment(yrMonth, 'YYYY/MM')
     }
   },


### PR DESCRIPTION
Fixes #11 

Bug was resulting in internalMomentValue to be set to Jan 1 / Dec 31 if min/max specified

Main change: .endOf() and .startOf() mutate the moment, so need to clone beforehand
Minor change: ternary for prepending 0 to months 1-9 is unnecessary